### PR TITLE
php 7.0 compatibility

### DIFF
--- a/ThirteenTemplate.php
+++ b/ThirteenTemplate.php
@@ -87,7 +87,7 @@ class ThirteenTemplate extends BaseTemplate {
 				&& $this->data['content_navigation']['views']['view']['class'] == 'selected'
 			) {
 				// actual title split
-				$parts = split('/', $title);
+				$parts = explode('/', $title);
 				$base_url = '';
 
 				for ($i = 0; $i < count($parts) - 1; $i ++)


### PR DESCRIPTION
split() removed in 7.0
https://secure.php.net/manual/en/function.split.php